### PR TITLE
Fix bug in randtest.amova

### DIFF
--- a/R/randtest.amova.R
+++ b/R/randtest.amova.R
@@ -22,7 +22,7 @@ randtest.amova <- function(xtest, nrepet = 99, ...) {
         longueurresult <- nrepet * (length(sigma) - 1)
         res <- testamova(distances, nrow(distances), nrow(distances), samples, nrow(samples), ncol(samples), structures, nrow(structures), ncol(structures), indic, sum(samples), nrepet, lesss[length(lesss)] / sum(samples), ddl, longueurresult)
         restests <- matrix(res, nrepet, length(sigma) - 1, byrow = TRUE)
-        alts <- rep("greater", length(names(structures)))
+        alts <- rep("greater", length(names(structures)) + 1)
         permutationtests <- as.krandtest(sim=restests,obs=sigma[(length(sigma) - 1):1],names= paste("Variations", c("within samples", "between samples", paste("between", names(structures)))),alter=c("less", alts),call=match.call())
     }
     else {

--- a/R/randtest.amova.R
+++ b/R/randtest.amova.R
@@ -22,8 +22,8 @@ randtest.amova <- function(xtest, nrepet = 99, ...) {
         longueurresult <- nrepet * (length(sigma) - 1)
         res <- testamova(distances, nrow(distances), nrow(distances), samples, nrow(samples), ncol(samples), structures, nrow(structures), ncol(structures), indic, sum(samples), nrepet, lesss[length(lesss)] / sum(samples), ddl, longueurresult)
         restests <- matrix(res, nrepet, length(sigma) - 1, byrow = TRUE)
-        
-        permutationtests <- as.krandtest(sim=restests,obs=sigma[(length(sigma) - 1):1],names= paste("Variations", c("within samples", "between samples", paste("between", names(structures)))),alter=c("less","greater","greater"),call=match.call())
+        alts <- rep("greater", length(names(structures)))
+        permutationtests <- as.krandtest(sim=restests,obs=sigma[(length(sigma) - 1):1],names= paste("Variations", c("within samples", "between samples", paste("between", names(structures)))),alter=c("less", alts),call=match.call())
     }
     else {
         longueurresult <- nrepet * (length(sigma) - 2)


### PR DESCRIPTION
Good day,

This bug came up in https://groups.google.com/forum/#!topic/poppr/D1gpqgQM2F0

There is no issue when comparing three hierarchical levels, but when there are four or more, 
the alternate hypothesis for every fourth level is incorrect due to the recycling of 
c("less", "greater", "greater").